### PR TITLE
Rename annotateCmd

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -17,7 +17,7 @@ var (
 	generateMarkdown bool
 )
 
-var annotateCmd = &cobra.Command{
+var analyzeCmd = &cobra.Command{
 	Use:   "analyze [path]",
 	Short: "Analyze App",
 	Args:  cobra.MaximumNArgs(1),
@@ -87,9 +87,9 @@ var annotateCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(annotateCmd)
-	annotateCmd.Flags().BoolVar(&generateHTML, "html", false, "Generate HTML visualization")
-	annotateCmd.Flags().BoolVar(&generateJSON, "json", false, "Generate JSON output file")
-	annotateCmd.Flags().BoolVar(&generateMarkdown, "markdown", false, "Generate Markdown report")
-	annotateCmd.Flags().StringVar(&outputDir, "output-dir", "", "Directory where the output files will be generated (default: current directory)")
+	rootCmd.AddCommand(analyzeCmd)
+	analyzeCmd.Flags().BoolVar(&generateHTML, "html", false, "Generate HTML visualization")
+	analyzeCmd.Flags().BoolVar(&generateJSON, "json", false, "Generate JSON output file")
+	analyzeCmd.Flags().BoolVar(&generateMarkdown, "markdown", false, "Generate Markdown report")
+	analyzeCmd.Flags().StringVar(&outputDir, "output-dir", "", "Directory where the output files will be generated (default: current directory)")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Short: "Bitrise CLI Plugin: Build Annotations",
+	Short: "Bitrise CLI Plugin: App Bundle Analyzer",
 }
 
 func Execute() {


### PR DESCRIPTION
## Summary
- rename `annotateCmd` to `analyzeCmd`
- update usage of `analyzeCmd` in `init`
- clarify plugin description in `rootCmd`

## Testing
- `go vet ./...` *(fails: proxyconnect tcp dial tcp 172.20.0.3:8080: connect: no route to host)*
- `go build ./...` *(fails: proxyconnect tcp dial tcp 172.20.0.3:8080: connect: no route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b8bf1aac08333a50ae26f93236084